### PR TITLE
Also build during the CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  fmt:
+  fmt_and_build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,7 @@ jobs:
       # Run cargo fmt linting on the source code
       - name: Run style linter
         run: cargo fmt -- --check
+
+      # Run the build to make sure it also compiles
+      - name: Run build
+        run: cargo build


### PR DESCRIPTION
This would have caught all three of the dependabot PRs left open without needing a manual test (we do still need that manual test for now for other reasons, but could have avoided doing the manual test when the cli can't compile at all)